### PR TITLE
Update requirements.yml

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
-- pureport.fabric
+- community.general
 


### PR DESCRIPTION
Hi there,

I am trying to run the demo and bumped into an error while the collection requirements were being installed. While checking it, I found that this collection - marked as a dependency to the demo project but apparently not used - seems to be related with a service no longer available. Hence this PR.

Replace pureport.fabric (which seems to be about https://www.pureport.com/ - which is no longer available), with community.general.